### PR TITLE
remove the ">>>" prefix on pip command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,9 @@ The main concept was inspired by those projects:
 Installation
 ************
 
->>> pip install django-mutant
+::
+
+    pip install django-mutant
 
 Make sure ``'django.contrib.contenttypes'`` and ``'mutant'`` are in
 your ``INSTALLED_APPS``


### PR DESCRIPTION
I was looking through your README and thought this line would be better without the ">>>" at the front, which makes it look like the command should be run in a python interpreter.
