### PR TITLE
Fix ContentType model lookup in migrations

### DIFF
--- a/mutant/contrib/boolean/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/boolean/migrations/0002_update_field_defs_app_label.py
@@ -13,7 +13,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'nullbooleanfielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/geo/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/geo/migrations/0002_update_field_defs_app_label.py
@@ -19,7 +19,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'polygonfielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/numeric/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/numeric/migrations/0002_update_field_defs_app_label.py
@@ -18,7 +18,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'smallintegerfielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/related/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/related/migrations/0002_update_field_defs_app_label.py
@@ -14,7 +14,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'onetoonefielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/temporal/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/temporal/migrations/0002_update_field_defs_app_label.py
@@ -14,7 +14,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'timefielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/text/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/text/migrations/0002_update_field_defs_app_label.py
@@ -13,7 +13,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'textfielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 

--- a/mutant/contrib/web/migrations/0002_update_field_defs_app_label.py
+++ b/mutant/contrib/web/migrations/0002_update_field_defs_app_label.py
@@ -16,7 +16,7 @@ def _update_field_def_cts_app_label(from_app_label, to_app_label, apps, schema_e
         'urlfielddefinition',
     ]
     cts.filter(
-        app_label=from_app_label, model=model_names
+        app_label=from_app_label, model__in=model_names
     ).update(app_label=to_app_label)
 
 


### PR DESCRIPTION
0002_update_field_defs_app_label migrations should use lookup while filtering ContentType, otherwise always return []